### PR TITLE
Fix error related to guide curve conversion

### DIFF
--- a/cpacs2to3/convert_coordinates.py
+++ b/cpacs2to3/convert_coordinates.py
@@ -292,14 +292,24 @@ def compute_new_guide_curve_points(tixi2, tigl2, tigl3, guide_curve_uid, n_profi
     return rX, rY, rZ
 
 
+def uses_cpacs3_guide_curve_definition(tixi_handle):
+    # check if the CPACS 2 file already uses a CPACS 3 conform guide curves definition
+    curve_interp_xpath = "cpacs/header/cpacsVersionGuideCurveInterp"
+    return tixi_handle.checkElement(curve_interp_xpath) and tixi_handle.getTextElement(curve_interp_xpath) == "3"
+
 def convert_guide_curve_points(tixi3, tixi2, tigl2, tigl3, keep_unused_profiles=False):
 
     # rename guideCurveProfiles to guideCurves
     if tixi3.checkElement("cpacs/vehicles/profiles/guideCurveProfiles"):
         tixi3.renameElement("cpacs/vehicles/profiles", "guideCurveProfiles", "guideCurves")
 
+    # check if there are any guide curves to convert
     xpath = "cpacs/vehicles/profiles/guideCurves"
     if not tixi3.checkElement(xpath):
+        return
+
+    if uses_cpacs3_guide_curve_definition(tixi3):
+        tixi3.removeElement("cpacs/header/cpacsVersionGuideCurveInterp")
         return
 
     logging.info("Adapting guide curve profiles to CPACS 3 definition")

--- a/cpacs2to3/convert_coordinates.py
+++ b/cpacs2to3/convert_coordinates.py
@@ -187,6 +187,8 @@ def find_guide_curve_using_profile(tixi2, profileUid):
     # check all guide curves of all fuselages and wings
     for type in ['fuselage', 'wing']:
         xpath = 'cpacs/vehicles/aircraft/model/{}s'.format(type)
+        if not tixi2.checkElement(xpath):
+            continue
         n = tixi2.getNumberOfChilds(xpath)
         for idx in range(0, n):
             xpathSegments = xpath + '/{}[{}]/segments'.format(type, idx + 1)
@@ -286,15 +288,16 @@ def compute_new_guide_curve_points(tixi2, tigl2, tigl3, guide_curve_uid, n_profi
 
 
 def convert_guide_curve_points(tixi3, tixi2, tigl2, tigl3, keep_unused_profiles=False):
+
+    # rename guideCurveProfiles to guideCurves
+    if tixi3.checkElement("cpacs/vehicles/profiles/guideCurveProfiles"):
+        tixi3.renameElement("cpacs/vehicles/profiles", "guideCurveProfiles", "guideCurves")
+
     xpath = "cpacs/vehicles/profiles/guideCurves"
     if not tixi3.checkElement(xpath):
         return
 
     logging.info("Adapting guide curve profiles to CPACS 3 definition")
-
-    # rename guideCurveProfiles to guideCurves
-    if tixi3.checkElement("cpacs/vehicles/profiles/guideCurveProfiles"):
-        tixi3.renameElement("cpacs/vehicles/profiles", "guideCurveProfiles", "guideCurves")
 
     nProfiles = tixi3.getNumberOfChilds(xpath)
     idx = 0

--- a/cpacs2to3/convert_coordinates.py
+++ b/cpacs2to3/convert_coordinates.py
@@ -246,7 +246,12 @@ def compute_new_guide_curve_points(tixi2, tigl2, tigl3, guide_curve_uid, n_profi
         logging.error("Guide Curve Conversion is only implemented for fuselage and wing guide curves!")
         return None
 
-    px, py, pz = tigl2.getGuideCurvePoints(guide_curve_uid, n_profile_points + 2)
+    try:
+        px, py, pz = tigl2.getGuideCurvePoints(guide_curve_uid, n_profile_points + 2)
+    except:
+        logging.error("Cannot parse CPACS 2 Guide Curves using TiGL. Try running cpacs2to3 with -f option.")
+        quit()
+        return None
 
     guideCurvePnts = np.zeros((3, n_profile_points + 2))
     guideCurvePnts[0, :] = px
@@ -262,7 +267,7 @@ def compute_new_guide_curve_points(tixi2, tigl2, tigl3, guide_curve_uid, n_profi
     if abs(znorm) < 1e-10:
         logging.error(
             "Error during guide curve profile point calculation: The last point and the first point seem to coincide!")
-        return
+        return None
 
     z = z / znorm
 

--- a/cpacs2to3/convert_coordinates.py
+++ b/cpacs2to3/convert_coordinates.py
@@ -292,12 +292,15 @@ def compute_new_guide_curve_points(tixi2, tigl2, tigl3, guide_curve_uid, n_profi
     return rX, rY, rZ
 
 
-def uses_cpacs3_guide_curve_definition(tixi_handle):
-    # check if the CPACS 2 file already uses a CPACS 3 conform guide curves definition
-    curve_interp_xpath = "cpacs/header/cpacsVersionGuideCurveInterp"
-    return tixi_handle.checkElement(curve_interp_xpath) and tixi_handle.getTextElement(curve_interp_xpath) == "3"
+def do_convert_guide_curves(tixi_handle):
+    # convert guide curves, if the curve_interp_xpath does not exist, or if if exists and is set to "1"
+    curve_interp_xpath = "cpacs/header/update/cpacs2to3/configuration/convertGuideCurves"
+    return (not tixi_handle.checkElement(curve_interp_xpath)) or tixi_handle.getTextElement(curve_interp_xpath) == "1"
 
 def convert_guide_curve_points(tixi3, tixi2, tigl2, tigl3, keep_unused_profiles=False):
+
+    if not do_convert_guide_curves(tixi3):
+        return
 
     # rename guideCurveProfiles to guideCurves
     if tixi3.checkElement("cpacs/vehicles/profiles/guideCurveProfiles"):
@@ -306,10 +309,6 @@ def convert_guide_curve_points(tixi3, tixi2, tigl2, tigl3, keep_unused_profiles=
     # check if there are any guide curves to convert
     xpath = "cpacs/vehicles/profiles/guideCurves"
     if not tixi3.checkElement(xpath):
-        return
-
-    if uses_cpacs3_guide_curve_definition(tixi3):
-        tixi3.removeElement("cpacs/header/cpacsVersionGuideCurveInterp")
         return
 
     logging.info("Adapting guide curve profiles to CPACS 3 definition")

--- a/cpacs2to3/cpacs_converter.py
+++ b/cpacs2to3/cpacs_converter.py
@@ -115,12 +115,11 @@ def fix_guide_curve_profile_element_names(tixi_handle):
     file_has_changed = False
 
     # rename guideCurves to guideCurveProfiles
-    xpath = "cpacs/vehicles/profiles/guideCurves"
-    if tixi_handle.checkElement(xpath):
+    if tixi_handle.checkElement("cpacs/vehicles/profiles/guideCurves"):
         tixi_handle.renameElement("cpacs/vehicles/profiles", "guideCurves", "guideCurveProfiles")
         file_has_changed = True
-        xpath = "cpacs/vehicles/profiles/guideCurveProfiles"
-
+    
+    xpath = "cpacs/vehicles/profiles/guideCurveProfiles"
     if not tixi_handle.checkElement(xpath):
         return file_has_changed
 

--- a/cpacs2to3/cpacs_converter.py
+++ b/cpacs2to3/cpacs_converter.py
@@ -117,11 +117,6 @@ def fix_guide_curve_profile_element_names(tixi_handle):
     if uses_cpacs3_guide_curve_definition(tixi_handle):
         return file_has_changed
 
-    # check if the CPACS 2 file already uses a CPACS 3 conform guide curves definition
-    curve_interp_xpath = "cpacs/header/cpacsVersionGuideCurveInterp"
-    if tixi_handle.checkElement(curve_interp_xpath) and tixi3.getTextElement(curve_interp_xpath) == "3":
-        return
-
     # rename guideCurves to guideCurveProfiles
     if tixi_handle.checkElement("cpacs/vehicles/profiles/guideCurves"):
         tixi_handle.renameElement("cpacs/vehicles/profiles", "guideCurves", "guideCurveProfiles")

--- a/cpacs2to3/cpacs_converter.py
+++ b/cpacs2to3/cpacs_converter.py
@@ -18,7 +18,7 @@ from tixi3 import tixi3wrapper
 from tixi3.tixi3wrapper import Tixi3Exception
 
 import cpacs2to3.tixi_helper as tixihelper
-from cpacs2to3.convert_coordinates import convert_geometry, uses_cpacs3_guide_curve_definition
+from cpacs2to3.convert_coordinates import convert_geometry, do_convert_guide_curves
 from cpacs2to3.tixi_helper import parent_path, element_name, element_index
 from cpacs2to3.uid_generator import uid_manager
 
@@ -114,7 +114,7 @@ def fix_guide_curve_profile_element_names(tixi_handle):
 
     file_has_changed = False
 
-    if uses_cpacs3_guide_curve_definition(tixi_handle):
+    if not do_convert_guide_curves(tixi_handle):
         return file_has_changed
 
     # rename guideCurves to guideCurveProfiles

--- a/cpacs2to3/cpacs_converter.py
+++ b/cpacs2to3/cpacs_converter.py
@@ -18,7 +18,7 @@ from tixi3 import tixi3wrapper
 from tixi3.tixi3wrapper import Tixi3Exception
 
 import cpacs2to3.tixi_helper as tixihelper
-from cpacs2to3.convert_coordinates import convert_geometry
+from cpacs2to3.convert_coordinates import convert_geometry, uses_cpacs3_guide_curve_definition
 from cpacs2to3.tixi_helper import parent_path, element_name, element_index
 from cpacs2to3.uid_generator import uid_manager
 
@@ -114,11 +114,19 @@ def fix_guide_curve_profile_element_names(tixi_handle):
 
     file_has_changed = False
 
+    if uses_cpacs3_guide_curve_definition(tixi_handle):
+        return file_has_changed
+
+    # check if the CPACS 2 file already uses a CPACS 3 conform guide curves definition
+    curve_interp_xpath = "cpacs/header/cpacsVersionGuideCurveInterp"
+    if tixi_handle.checkElement(curve_interp_xpath) and tixi3.getTextElement(curve_interp_xpath) == "3":
+        return
+
     # rename guideCurves to guideCurveProfiles
     if tixi_handle.checkElement("cpacs/vehicles/profiles/guideCurves"):
         tixi_handle.renameElement("cpacs/vehicles/profiles", "guideCurves", "guideCurveProfiles")
         file_has_changed = True
-    
+
     xpath = "cpacs/vehicles/profiles/guideCurveProfiles"
     if not tixi_handle.checkElement(xpath):
         return file_has_changed


### PR DESCRIPTION
There were a few issues with the guide curve conversion mechanism. See #15 for a detailed description. This PR fixes #15. This PR includes the following changes:

 - fuselages and wings are not mandatory anymore
 - With the `--fix-errors` command line option, guideCurveProfiles are translated to a TIGL2-interpretable format before conversion
 - If the input file happens to have CPACS 3 conform guide curves, the user must add a Boolean node `"cpacs/header/update/cpacs2to3/configuration/convertGuideCurves"` to the cpacs file that explicitly states that guide curves shall not be converted:

   ```xml
   <?xml version="1.0" encoding="utf-8"?>
   <cpacs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://github.com/DLR-LY/CPACS/blob/v3.0/schema/cpacs_schema.xsd?raw=true">
     <header>
       <name>Heart of Gold</name>
       <description>Added towel rack</description>
       <creator>Arthur Dent</creator>
       <timestamp>2019-09-10T12:59:46</timestamp>
       <version>0.0</version>
       <cpacsVersion>2.1</cpacsVersion>
       <update>
         <cpacs2to3>
           <configuration>
             <convertGuideCurves>0</convertGuideCurves>
           </configuration>
         </cpacs2to3>
       </update>
     </header>
   ```
   If this node does not exist or its content is "1", guide curves will be converted.