### PR TITLE
# Compatibility Update

### DIFF
--- a/cpacs2to3/cpacs_converter.py
+++ b/cpacs2to3/cpacs_converter.py
@@ -538,8 +538,10 @@ def upgrade_2_to_3(cpacs_handle, args):
     change_cpacs_version(cpacs_handle, "3.0")
     convert_cpacs_xml(cpacs_handle)
 
+    configurations = args.configurations.split(',') if args.configurations is not None else []
+
     # perform geometric conversions using tigl
-    convert_geometry(filename, cpacs_handle, old_cpacs_file)
+    convert_geometry(filename, cpacs_handle, old_cpacs_file, configurations=configurations)
 
 
 def upgrade_3_to_31(cpacs_handle, args):
@@ -661,6 +663,7 @@ def main():
     parser.add_argument('-o', metavar='output_file', help='Name of the output file.')
     parser.add_argument('--fix-errors', '-f', help='try to fix empty and duplicate uids/elements',  action="store_true")
     parser.add_argument('--target-version', '-v', default="3.2")
+    parser.add_argument('--configurations', '-c', default=None)
 
     args = parser.parse_args()
     filename = args.input_file

--- a/cpacs2to3/tixi_helper.py
+++ b/cpacs2to3/tixi_helper.py
@@ -79,3 +79,9 @@ def next_parent_uid(tixi_handle, current_path):
         parent_uid = ''
 
     return parent_uid, elem
+
+
+def list_configurations(tixih):
+    models = resolve_xpaths(tixih, '//vehicles/*/model')
+    configuration = [tixih.getTextAttribute(imodel, 'uID') for imodel in models]
+    return configuration

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author='Martin Siggel',
     author_email=',martin.siggel@dlr.de',
     license='Apache-2.0',
-    requires=['tigl3', 'tigl', 'tixi', 'semver', 'numpy'],
+    install_requires=['tigl3', 'tigl', 'semver', 'numpy'],
     packages=['cpacs2to3'],
     entry_points={
         'console_scripts': ['cpacs2to3 = cpacs2to3.cpacs_converter:main']}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ class TestCase:
     old_cpacs_file = None
     new_cpacs_file = None
     fix_errors = False
+    configurations = None
 
     def __init__(self, file, old, new):
         self.input_file = file


### PR DESCRIPTION
Fixes #25

- added fail save OCC import for newer versions
- added option to choose the `configurations` to be converted
- slight update on setup.py for requirements, removed explicit `tixi` and `tixi3` requirements, since pip is not capable of resolving this. Those are implicitly installed with `tigl` and `tigl3` anyways